### PR TITLE
Change default code owners to episerver/cms-delivery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # See https://help.github.com/articles/about-code-owners/
 
 # Default owners for everything in this repo
-*	@hennys @shahramshahram @johanpetersson @jbearfoot @pergunsarfs @jotiepiserver @tidyui
+*	@episerver/cms-delivery


### PR DESCRIPTION
Updated default code owners for the repository.